### PR TITLE
[REFACTOR] xButton을 눌렀을 떄 로직 구현 / SearchViewController에서 구현

### DIFF
--- a/SeSAC Shopping(CodeBase).xcodeproj/xcuserdata/namhyeonjeong.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/SeSAC Shopping(CodeBase).xcodeproj/xcuserdata/namhyeonjeong.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>SeSAC Shopping(CodeBase).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>SnapKitPlayground (Playground) 1.xcscheme</key>
 		<dict>

--- a/SeSAC Shopping(CodeBase)/Search/SearchViewController.swift
+++ b/SeSAC Shopping(CodeBase)/Search/SearchViewController.swift
@@ -72,7 +72,19 @@ class SearchViewController: UIViewController {
             recentSearchTableView.isHidden = true
         }
     }
-
+    
+    @objc func xButtonClicked(_ sender: UIButton) {
+        print(#function)
+        var recentSearchList = UserDefaultManager.shared.ud.array(forKey: "RecentSearch")!
+    
+        // 받아온 xButton의 태그를 인덱스로 가지는 리스트 삭제
+        recentSearchList.remove(at: sender.tag)
+        
+        // 유저디폴트에 다시 저장
+        UserDefaultManager.shared.ud.set(recentSearchList, forKey: "RecentSearch")
+        
+        recentSearchTableView.reloadData() // 넘겨받은 tableview 다시 로드 -> 다시 로드하면서 tag값도 차례대로 다시 지정해준다.와 머임!!!! & remove(at:)하면 알아서 앞으로 땡겨쥼ㅎㅎ
+    }
 
 }
 
@@ -208,8 +220,12 @@ extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // 유저디폴트 분기문
         let cell = recentSearchTableView.dequeueReusableCell(withIdentifier: RecentSearchTableViewCell.identifier, for: indexPath) as! RecentSearchTableViewCell
-  
+        
+        cell.xButton.tag = indexPath.row // tag지정
+        
         cell.configureCell(text: recentSearchList[indexPath.row], tableview: recentSearchTableView)
+        
+        cell.xButton.addTarget(self, action: #selector(xButtonClicked), for: .touchUpInside)
     
         return cell
     }

--- a/SeSAC Shopping(CodeBase)/TableViewCell/RecentSearchTableViewCell.swift
+++ b/SeSAC Shopping(CodeBase)/TableViewCell/RecentSearchTableViewCell.swift
@@ -41,19 +41,7 @@ class RecentSearchTableViewCell: UITableViewCell {
         recentLabel.text = text as? String
         self.tableView = tableview
     }
-    
-    @objc func xButtonClicked() {
-        print(#function)
-        var recentSearchList = UserDefaultManager.shared.ud.array(forKey: "RecentSearch")!
-        
-        recentSearchList.removeAll (where: {text in
-            text as! String == recentLabel.text!
-        })
-        // 유저디폴트에 다시 저장
-        UserDefaultManager.shared.ud.set(recentSearchList, forKey: "RecentSearch")
-        
-        tableView.reloadData() // 넘겨받은 tableview 다시 로드
-    }
+
 }
 
 extension RecentSearchTableViewCell {
@@ -74,7 +62,7 @@ extension RecentSearchTableViewCell {
         xButton.setImage(UIImage(systemName: "xmark"), for: .normal)
         xButton.tintColor = CustomColor.textColor
         print("dfdf")
-        xButton.addTarget(self, action: #selector(xButtonClicked), for: .touchUpInside)
+
     }
     
     func configureConstraints() {


### PR DESCRIPTION
## 🚀관련 이슈
- close #4 

## 💎작업 내용
- addtarget로직 SearchViewController로 옮기기
- 각 xButton에 tag지정
- tag인덱스에 해당하는 최근검색어 리스트를 지운뒤 다시 유저디폴트에 수정 & 테이블뷰 reload


## ⭐️참고 사항
- xButton을 눌렀을 때 함수를 구현해보면 (_sender: UIButton)으로 매개변수를 보낼 수 있다.
- List.remove(at:)을 해주면 삭제된 요소 뒤는 다시 앞으로 당겨준다 
그리고 최근검색어 리스트에 추가나 삭제가 되었을 떄 다시 테이블뷰를 reload해주니까 tag도 다시 지정되게 되어있음

<img width="40%" alt="스크린샷 2024-01-29 오후 7 25 37" src="https://github.com/nhyeonjeong/SeSAC-Shopping-CodeBase-/assets/102401977/7bbb0747-4bcc-45d1-9af0-9016c8eaf0de">
<img width="40%" alt="스크린샷 2024-01-29 오후 7 24 29" src="https://github.com/nhyeonjeong/SeSAC-Shopping-CodeBase-/assets/102401977/40a0e7d3-b18a-4947-8b64-636865c377b7">


